### PR TITLE
Speed up find workspace root

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ For example, with [lazy.nvim](https://github.com/folke/lazy.nvim), the minimum c
 ```lua
 {
   'll-nick/mrt.nvim',
+  dependencies = { 'nvim-lua/plenary.nvim' },
 }
 ```
 
@@ -38,6 +39,7 @@ A more complete example:
 ```lua
 {
     "ll-nick/mrt.nvim",
+    dependencies = { 'nvim-lua/plenary.nvim' },
 
     config = function()
         require("mrt").setup({

--- a/lua/mrt/utils.lua
+++ b/lua/mrt/utils.lua
@@ -1,3 +1,5 @@
+local Path = require("plenary.path")
+
 local M = {}
 
 local execute_in_new_nvim_pane = function(command, pane_height)
@@ -34,21 +36,20 @@ M.command_in_current_file_directory = function(command)
 	return execute_command
 end
 
+M.find_workspace_root = function()
+	local current_dir = vim.fn.getcwd()
+	while current_dir ~= "/" do
+		local catkin_tools_path = Path:new(current_dir, ".catkin_tools")
+		if catkin_tools_path:exists() and catkin_tools_path:is_dir() then
+			return current_dir
+		end
+		current_dir = Path:new(current_dir):parent().filename
+	end
+	return nil
+end
+
 M.is_catkin_workspace = function()
-	local handle = io.popen("mrt catkin locate 2>&1")
-	if not handle then
-		print("Failed to open pipe for command execution.")
-		return false
-	end
-
-	local result = handle:read("*a")
-	handle:close()
-
-	if result:match("No_catkin_workspace_root_found") or result:match("catkin: command not found") then
-		return false
-	end
-
-	return true
+	return M.find_workspace_root() ~= nil
 end
 
 return M


### PR DESCRIPTION
`catkin locate` is extremely slow, so this replaces that with a simple search for a `.catkin_tools` directory from the cwd upwards.

Note: This now requires `plenary.nvim` as an additional dependency but chances are most people will have that one installed anyway.