### PR TITLE
Add package picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ If you did and wonder how you can move your VS Code based workflow to Neovim, th
 
 - Execute builds with a single command
 - Run build commands in a new neovim or tmux pane
+- Switch packages using telescope
 - Switch your catkin profile interactively
  
 ## ⚡️ Requirements
@@ -31,16 +32,20 @@ For example, with [lazy.nvim](https://github.com/folke/lazy.nvim), the minimum c
 ```lua
 {
   'll-nick/mrt.nvim',
-  dependencies = { 'nvim-lua/plenary.nvim' },
-}
+  dependencies = { 
+    { 'nvim-lua/plenary.nvim' },
+    { 'nvim-telescope/telescope.nvim' },
+  }
 ```
 
 A more complete example:
 ```lua
 {
     "ll-nick/mrt.nvim",
-    dependencies = { 'nvim-lua/plenary.nvim' },
-
+    dependencies = { 
+      { 'nvim-lua/plenary.nvim' },
+      { 'nvim-telescope/telescope.nvim' },
+    },
     config = function()
         require("mrt").setup({
             pane_handler = "tmux",
@@ -62,6 +67,7 @@ A more complete example:
 - `:MrtBuildWorkspace`: Build the entire catkin workspace
 - `:MrtBuildCurrentPackage`: Build the current package
 - `:MrtBuildCurrentPackageTests`: Build tests for the current package
+- `:MrtPickCatkinPackage`: Open the Readme of a catkin package using telescope
 - `:MrtSwitchCatkinProfile`: Switch the catkin profile interactively
 
 ### 🔧 Configuration

--- a/lua/mrt/init.lua
+++ b/lua/mrt/init.lua
@@ -3,6 +3,7 @@ local mrt = {}
 local build = require("mrt.build")
 local catkin_profile = require("mrt.catkin_profile")
 local config = require("mrt.config")
+local package_picker = require("mrt.package_picker")
 local utils = require("mrt.utils")
 
 mrt.setup = config.setup
@@ -41,6 +42,15 @@ mrt.switch_catkin_profile = function()
 	end
 
 	catkin_profile.switch_profile_ui()
+end
+
+mrt.pick_catkin_package = function()
+	if not utils.is_catkin_workspace() then
+		print("This is not a valid Catkin workspace.")
+		return
+	end
+
+	package_picker.pick_catkin_package()
 end
 
 return mrt

--- a/lua/mrt/package_picker.lua
+++ b/lua/mrt/package_picker.lua
@@ -1,0 +1,89 @@
+local actions = require("telescope.actions")
+local action_state = require("telescope.actions.state")
+local finders = require("telescope.finders")
+local previewers = require("telescope.previewers")
+local pickers = require("telescope.pickers")
+local Path = require("plenary.path")
+local scan = require("plenary.scandir")
+local utils = require("mrt.utils")
+
+local M = {}
+
+local list_packages = function(workspace_path)
+	local src_path = workspace_path .. "/src"
+	local dirs = scan.scan_dir(src_path, { depth = 1, add_dirs = true, only_dirs = true })
+
+	return dirs
+end
+
+local find_readme_or_fallback_file = function(package_path)
+	local readme_path = Path:new(package_path):joinpath("README.md")
+	if readme_path:exists() then
+		return readme_path:absolute()
+	end
+
+	-- Fallback: Find any file in the package directory
+	local files = scan.scan_dir(package_path, { depth = 1, add_dirs = false })
+	if #files > 0 then
+		return files[1]
+	end
+
+	return nil -- No files found
+end
+
+M.pick_catkin_package = function()
+	local workspace_path = utils.find_workspace_root()
+	local packages = list_packages(workspace_path)
+
+	if vim.tbl_isempty(packages) then
+		print("No packages found in " .. workspace_path .. "/src")
+		return
+	end
+
+	pickers
+		.new({}, {
+			prompt_title = "Find Package",
+			finder = finders.new_table({
+				results = packages,
+				entry_maker = function(entry)
+					local package_name = Path:new(entry):make_relative(workspace_path .. "/src")
+					return {
+						value = entry,
+						display = package_name,
+						ordinal = package_name,
+					}
+				end,
+			}),
+			sorter = require("telescope.sorters").get_generic_fuzzy_sorter(),
+			previewer = previewers.new_termopen_previewer({
+				get_command = function(entry)
+					local package_path = entry.value
+					local preview_file = find_readme_or_fallback_file(package_path)
+					if preview_file then
+						return { "cat", preview_file }
+					else
+						return { "echo", "No files available in this package." }
+					end
+				end,
+			}),
+			attach_mappings = function(prompt_bufnr, map)
+				actions.select_default:replace(function()
+					actions.close(prompt_bufnr)
+					local selection = action_state.get_selected_entry()
+					if selection then
+						local package_path = selection.value
+						local file_to_open = find_readme_or_fallback_file(package_path)
+						if file_to_open then
+							vim.cmd("edit " .. file_to_open)
+						else
+							vim.notify("No files found in " .. package_path, vim.log.levels.WARN)
+						end
+					end
+				end)
+				return true
+			end,
+		})
+		:find()
+end
+
+return M

--- a/plugin/mrt.vim
+++ b/plugin/mrt.vim
@@ -3,6 +3,7 @@ if exists('g:loaded_mrt_vim') | finish | endif
 command! -nargs=0 MrtBuildWorkspace lua require'mrt'.build_workspace()
 command! -nargs=0 MrtBuildCurrentPackage lua require'mrt'.build_current_package()
 command! -nargs=0 MrtBuildCurrentPackageTests lua require'mrt'.build_current_package_tests()
+command! -nargs=0 MrtPickCatkinPackage lua require'mrt'.pick_catkin_package()
 command! -nargs=0 MrtSwitchCatkinProfile lua require'mrt'.switch_catkin_profile()
 
 let g:loaded_mrt_vim = 1


### PR DESCRIPTION
This uses telescope to search through all packages in the workspace. When picked, it will open up the package's Readme.
In combination with per-repo-pickers, this is a powerful way to navigate large catkin workspaces.