### PR TITLE
Speed up profile switch

### DIFF
--- a/lua/mrt/catkin_profile.lua
+++ b/lua/mrt/catkin_profile.lua
@@ -1,3 +1,5 @@
+local Path = require("plenary.path")
+
 local utils = require("mrt.utils")
 
 --- Activate the given catkin profile.
@@ -13,7 +15,9 @@ end
 
 local M = {}
 M.switch_profile_ui = function()
-    local profiles = utils.get_catkin_profiles()
+    local cwd = Path:new(vim.fn.getcwd())
+    local ws_root = utils.find_workspace_root(cwd)
+    local profiles = utils.get_catkin_profiles(ws_root)
 
     if not profiles then
         vim.notify("Failed to get catkin profiles.")

--- a/lua/mrt/catkin_profile.lua
+++ b/lua/mrt/catkin_profile.lua
@@ -7,10 +7,16 @@ local utils = require("mrt.utils")
 local set_profile = function(profile)
     local handle = io.popen("mrt catkin profile set " .. profile)
     if not handle then
-        vim.notify("Failed to open pipe for command execution.")
+        vim.notify("Failed to open pipe for command execution.", vim.log.levels.ERROR)
         return
     end
+
+    local result = handle:read("*a")
     handle:close()
+
+    if not result or result == "" then
+        vim.notify("Failed to switch profile. Command might not have executed properly.", vim.log.levels.ERROR)
+    end
 end
 
 local M = {}

--- a/lua/mrt/utils.lua
+++ b/lua/mrt/utils.lua
@@ -29,43 +29,60 @@ end
 --- @field active string|nil The currently active catkin profile.
 --- @field available string[] A list of available profiles excluding the active one.
 
+--- Reads the active profile from profiles.yaml
+--- @param profiles_yaml Path The path to profiles.yaml
+--- @return string|nil The active profile name or nil if not found
+local function get_active_profile(profiles_yaml)
+    if not profiles_yaml:exists() then
+        return nil
+    end
+
+    for _, line in ipairs(profiles_yaml:readlines()) do
+        local name = line:match("active:%s*(.+)")
+        if name then
+            return name
+        end
+    end
+    return nil
+end
+
+--- Retrieves all available catkin profiles
+--- @param profile_path Path The path to the profiles directory
+--- @return table A list of profile names
+local function get_available_profiles(profile_path)
+    if not profile_path:exists() then
+        return {}
+    end
+
+    local available_profiles = {}
+    local profiles_absolute = scan.scan_dir(profile_path.filename, { depth = 1, add_dirs = true, only_dirs = true })
+
+    for _, profile in ipairs(profiles_absolute) do
+        table.insert(available_profiles, Path:new(profile):make_relative(profile_path.filename))
+    end
+
+    return available_profiles
+end
+
 --- Retrieves the active and available catkin profiles
---- @param ws_root Path A directory inside the catkin workspace.
---- @return CatkinProfiles|nil A table containing the active profile and available profiles or nil if the command execution failed.
+--- @param ws_root Path The root of the catkin workspace
+--- @return table|nil A table containing the active profile and available profiles, or nil if invalid.
 M.get_catkin_profiles = function(ws_root)
     if not ws_root then
         return nil
     end
 
     local profile_path = ws_root:joinpath(".catkin_tools/profiles")
-    if not profile_path:exists() then
-        return nil
-    end
-
     local profiles_yaml = profile_path:joinpath("profiles.yaml")
-    if not profiles_yaml:exists() then
-        return nil
-    end
 
-    local active_profile = nil
-    if profiles_yaml:exists() then
-        for _, line in ipairs(profiles_yaml:readlines()) do
-            local name = line:match("active: (.+)")
-            if name then
-                active_profile = name
-                break
-            end
-        end
-    end
+    local active_profile = get_active_profile(profiles_yaml)
+    local available_profiles = get_available_profiles(profile_path)
 
-    local available_profiles_absolute =
-        scan.scan_dir(profile_path.filename, { depth = 1, add_dirs = true, only_dirs = true })
-    local available_profiles = {}
-    for _, profile in ipairs(available_profiles_absolute) do
-        local profile_name = Path:new(profile):make_relative(profile_path.filename)
-        if profile_name ~= active_profile then
-            table.insert(available_profiles, profile_name)
-        end
+    -- Remove the active profile from available profiles
+    if active_profile then
+        available_profiles = vim.tbl_filter(function(p)
+            return p ~= active_profile
+        end, available_profiles)
     end
 
     return {


### PR DESCRIPTION
This removes the delay that occurred before the switch profile prompt by finding the available and active profiles another way. Instead of running `catkin profile list` (which apparently is super slow), just parse the contents of the .catkin_tools directory.