### PR TITLE
Fix a wrongly defined field name in the catkin parser

### DIFF
--- a/lua/mrt/overseer.lua
+++ b/lua/mrt/overseer.lua
@@ -43,7 +43,7 @@ local catkin_parser = {
                         "lnum",
                         "col",
                         "type",
-                        "message",
+                        "text",
                     },
                 },
                 -- Terminate the loop when we find the start of the next package.


### PR DESCRIPTION
It's `text` not `message`, see `:h setqflist`